### PR TITLE
Replace pry-debugger with pry-byebug killing support for Ruby versions < 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0 (2014-04-25)
+
+* Replaced pry-debugger with pry-byebug. This change breaks support for Ruby versions older than 2.0.0
+
 ## 0.2.0 (2014-01-01)
 
 * Prompt layout now more configurable.  Added a new dependency on [colorize][colorize].
@@ -9,7 +13,6 @@
 [pry]:                 http://pry.github.com
 [pry-doc]:             https://github.com/pry/pry-doc
 [pry-stack_explorer]:  https://github.com/pry/pry-stack_explorer
-[pry-debugger]:        https://github.com/nixme/pry-debugger
 [pry-byebug]:          https://github.com/deivid-rodriguez/pry-byebug
 [pry-rails]:           https://github.com/rweng/pry-rails
 [awesome_print]:       https://github.com/michaeldv/awesome_print

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Icepick
 =======
 © {[doomspork](https://github.com/doomspork)} 2014
 
-Current version is `0.2.0` [Changelog][changelog].
+Current version is `1.0.0` [Changelog][changelog].
 
 __Icepick__ bundles a set of useful tools, plugins, and configurations together:
 
@@ -13,7 +13,7 @@ __Icepick__ bundles a set of useful tools, plugins, and configurations together:
 * [Pry Rails][pry-rails] adds Rails helpers to Pry like `show-routes` and `show-models` 
 * [Awesome Print][awesome_print] colorizes and formats output
 
-Ruby 1.9.2+ only. Support included for Rails 3 and Rails 4. 
+Ruby 2.0.0+ only. Support included for Rails 3 and Rails 4. 
 
 ## Usage
 
@@ -70,7 +70,6 @@ Feel free to open [Issues][issues] or submit [Pull Requests][pullrequest] for co
 [pry]:                 http://pry.github.com
 [pry-doc]:             https://github.com/pry/pry-doc
 [pry-stack_explorer]:  https://github.com/pry/pry-stack_explorer
-[pry-debugger]:        https://github.com/nixme/pry-debugger
 [pry-byebug]:          https://github.com/deivid-rodriguez/pry-byebug
 [pry-rails]:           https://github.com/rweng/pry-rails
 [awesome_print]:       https://github.com/michaeldv/awesome_print

--- a/icepick.gemspec
+++ b/icepick.gemspec
@@ -17,12 +17,12 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   # Dependencies
-  gem.required_ruby_version = '>= 1.9.2'
+  gem.required_ruby_version = '>= 2.0.0'
   gem.add_runtime_dependency 'pry',                 '~> 0.9.12'
   gem.add_runtime_dependency 'pry-doc',             '~> 0.4.6'
   gem.add_runtime_dependency 'pry-rails',           '~> 0.3.2'
   gem.add_runtime_dependency 'pry-stack_explorer',  '~> 0.4.9'
-  gem.add_runtime_dependency 'pry-debugger',        '~> 0.2.2'
+  gem.add_runtime_dependency 'pry-byebug',          '~> 1.3.2'
   gem.add_runtime_dependency 'colorize',            '~> 0.6.0'
   gem.add_runtime_dependency 'awesome_print',       '~> 1.2'
   gem.add_runtime_dependency 'railties',            '>= 3.0', '< 5.0'

--- a/lib/icepick.rb
+++ b/lib/icepick.rb
@@ -5,7 +5,7 @@ require 'icepick/prompt'
 require 'pry'
 require 'pry-doc'
 require 'pry-stack_explorer'
-require 'pry-debugger'
+require 'pry-byebug'
 require 'awesome_print'
 require 'readline'
 

--- a/lib/icepick/version.rb
+++ b/lib/icepick/version.rb
@@ -1,3 +1,3 @@
 module Icepick
-  VERSION = '0.2.0'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
Here are the changes to make the gem support ruby 2.0.0+. Let me know if you see anything missing/wrong.
