### PR TITLE
suppress useless warnings when running bin/icepick

### DIFF
--- a/bin/icepick
+++ b/bin/icepick
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# This patch supresses warnings about Unresolved specs during Gem::Specification.reset
+# This patch suppresses warnings about Unresolved specs during Gem::Specification.reset
 require 'patches/rubygems/specification'
 # (C) Sean Callan (doomspork)
 # MIT license

--- a/lib/patches/rubygems/specification.rb
+++ b/lib/patches/rubygems/specification.rb
@@ -1,4 +1,4 @@
-# This is used to supress warnings about Unresolved specs during Gem::Specification.reset
+# This is used to suppress warnings about Unresolved specs during Gem::Specification.reset
 module Gem
   class Specification
     class << self


### PR DESCRIPTION
This is a quick little patch to make the icepick bin shut up about: `Unresolved specs during Gem::Specification.reset`
